### PR TITLE
Lexer supports 'ident', ';', '=', 'return'

### DIFF
--- a/include/tiny-c/Lexer/Lexer.h
+++ b/include/tiny-c/Lexer/Lexer.h
@@ -13,13 +13,17 @@ public:
   enum TokenKind : unsigned short {
     eoi,
     unknown,
+    ident,
     number,
+    semicolon,
+    equal,
     plus,
     minus,
     star,
     slash,
     l_paren,
-    r_paren
+    r_paren,
+    KW_return
   };
 
 private:

--- a/lib/Lexer/Lexer.cpp
+++ b/lib/Lexer/Lexer.cpp
@@ -26,11 +26,13 @@ void Lexer::next(Token &Result) {
     return;
   }
   if (charinfo::isLetter(*BufferPtr)) {
-    assert(false);
-    //const char *end = BufferPtr + 1;
-    //while (charinfo::isLetter(*end))
-    //  end++;
-    //llvm::StringRef Name(BufferPtr, end - BufferPtr);
+    const char *end = BufferPtr + 1;
+    while (charinfo::isLetter(*end))
+      end++;
+    llvm::StringRef Name(BufferPtr, end - BufferPtr);
+    Token::TokenKind Kind = Name == "return" ? Token::KW_return : Token::ident;
+    formToken(Result, end, Kind);
+    return;
   } else if (charinfo::isDigit(*BufferPtr)) {
     const char *end = BufferPtr + 1;
     while (charinfo::isDigit(*end))
@@ -41,6 +43,8 @@ void Lexer::next(Token &Result) {
     switch (*BufferPtr) {
 #define CASE(ch, tok) \
 case ch: formToken(Result, BufferPtr + 1, tok); break
+CASE(';', Token::semicolon);
+CASE('=', Token::equal);
 CASE('+', Token::plus);
 CASE('-', Token::minus);
 CASE('*', Token::star);

--- a/unittest/LexerTest.cpp
+++ b/unittest/LexerTest.cpp
@@ -32,4 +32,43 @@ TEST(LexerTest, tokenizeTest) {
   EXPECT_EQ(Token::eoi, tok.getKind());
 }
 
+TEST(LexerTest, localVariableTest) {
+  Lexer Lex("   \
+    num = 100;  \
+    return num; \
+  ");
+  Token tok;
+
+  Lex.next(tok);
+  EXPECT_EQ("num", tok.getText());
+  EXPECT_EQ(Token::ident, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ("=", tok.getText());
+  EXPECT_EQ(Token::equal, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ("100", tok.getText());
+  EXPECT_EQ(Token::number, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ(";", tok.getText());
+  EXPECT_EQ(Token::semicolon, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ("return", tok.getText());
+  EXPECT_EQ(Token::KW_return, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ("num", tok.getText());
+  EXPECT_EQ(Token::ident, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ(";", tok.getText());
+  EXPECT_EQ(Token::semicolon, tok.getKind());
+
+  Lex.next(tok);
+  EXPECT_EQ(Token::eoi, tok.getKind());
+}
+
 } // namespace


### PR DESCRIPTION
Closes #7 